### PR TITLE
Fix logical error in ReviewApplication choice

### DIFF
--- a/daml/Lab3.daml
+++ b/daml/Lab3.daml
@@ -55,7 +55,7 @@ template CLPApplication
                     now <- getTime
 
                     -- uncomment the following statement for Problem 3.2
-                    ---assertMsg "Assertion failure: Duplicate customer Id" (isSome account)
+                    ---assertMsg "Assertion failure: Duplicate customer Id" (isNone account)
 
                     if (isSome account) then do
                         -- uncomment the following statement for Problem 3.3


### PR DESCRIPTION
The assertMsg function in ReviewApplication choice should use isNone instead of isSome to assert that an account contract for the given customer ID doesn't already exist on the ledger.